### PR TITLE
Add clarity to bypass list translation (Spanish)

### DIFF
--- a/src/_locales/es/messages.json
+++ b/src/_locales/es/messages.json
@@ -168,7 +168,7 @@
 		"description": ""
 	},
 	"settingsTabBypass": {
-		"message": "Vaciar la lista",
+		"message": "Lista de exclusion",
 		"description": ""
 	},
 	"settingsTabBackupRestore": {
@@ -804,7 +804,7 @@
 		"description": ""
 	},
 	"settingsBypassList": {
-		"message": "Vaciar la lista:",
+		"message": "Lista de exclusiones:",
 		"description": ""
 	},
 	"settingsBypassListHint": {
@@ -816,11 +816,11 @@
 		"description": ""
 	},
 	"settingsSaveBypassSuccess": {
-		"message": "La lista del proxy fue guardada exitosamente.",
+		"message": "La lista de exclusion del proxy fue guardada exitosamente.",
 		"description": ""
 	},
 	"settingsBypassInvalid": {
-		"message": "Configuración de bypass no válido",
+		"message": "Configuración de exclusión no válida",
 		"description": ""
 	}
 }


### PR DESCRIPTION
Improve the clarity of bypass list ("Vaciar Lista" is something like empty list)