### PR TITLE
Firefox: add option to always enable in Private Browsing

### DIFF
--- a/src/_locales/default-messages.json
+++ b/src/_locales/default-messages.json
@@ -199,6 +199,10 @@
 		"message": "Always Mode",
 		"description": ""
 	},
+	"proxyableGridData_LogType_AlwaysEnabledIncognito": {
+		"message": "Always Incognito Mode",
+		"description": ""
+	},
 	"proxyableGridData_LogType_ProxyPerOrigin": {
 		"message": "From Parent Tab",
 		"description": ""
@@ -265,6 +269,14 @@
 	},
 	"settingsGeneralProxyPerOriginDisabled": {
 		"message": "Proxy per tab/origin disabled",
+		"description": ""
+	},
+	"settingsGeneralAlwaysProxyIncognito": {
+		"message": "Always enabled proxy for incognito mode",
+		"description": ""
+	},
+	"settingsGeneralAlwaysProxyIncognitoDesc": {
+		"message": "Check if you want to switch to 'Always Enabled' in Private Browsing mode. This option has no effect in 'Direct' proxy mode.",
 		"description": ""
 	},
 	"settingsGeneralSyncing": {

--- a/src/core/ProxyEngineFirefox.ts
+++ b/src/core/ProxyEngineFirefox.ts
@@ -106,6 +106,14 @@ export class ProxyEngineFirefox {
 			if (!requestDetails.url)
 				return { type: "direct" };
 
+			// Check if we should proxy the request because we're running in incognito mode
+			if (settings.proxyMode != ProxyModeType.Direct
+				&& settings.options.alwaysProxyIncognito
+				&& TabManager.getTab(requestDetails.tabId).incognito) {
+				proxyLog.logType = ProxyableLogType.AlwaysEnabledIncognito;
+				return ProxyEngineFirefox.getResultProxyInfo(settings.activeProxyServer);
+			}
+
 			// checking if request is special
 			let specialRequest = ProxyEngineSpecialRequests.getProxyMode(requestDetails.url, true);
 			if (specialRequest !== null) {

--- a/src/core/definitions.ts
+++ b/src/core/definitions.ts
@@ -183,7 +183,8 @@ export enum ProxyableLogType {
 	ByPassed,
 	SystemProxyApplied,
 	AlwaysEnabled,
-	ProxyPerOrigin
+	ProxyPerOrigin,
+	AlwaysEnabledIncognito
 }
 
 export class ProxyableLogDataType {
@@ -210,7 +211,8 @@ export class ProxyableLogDataType {
 
 		if (this.logType == ProxyableLogType.AlwaysEnabled ||
 			this.logType == ProxyableLogType.MatchedRule ||
-			this.logType == ProxyableLogType.ProxyPerOrigin)
+			this.logType == ProxyableLogType.ProxyPerOrigin ||
+			this.logType == ProxyableLogType.AlwaysEnabledIncognito)
 			return true;
 		return false;
 	}
@@ -222,7 +224,8 @@ export class ProxyableLogDataType {
 		if (this.logType == ProxyableLogType.AlwaysEnabled ||
 			this.logType == ProxyableLogType.Special ||
 			this.logType == ProxyableLogType.SystemProxyApplied ||
-			this.logType == ProxyableLogType.ByPassed)
+			this.logType == ProxyableLogType.ByPassed ||
+			this.logType == ProxyableLogType.AlwaysEnabledIncognito)
 			return false;
 		return true;
 	}
@@ -271,6 +274,7 @@ export class GeneralOptions implements Cloneable {
 	public displayFailedOnBadge: boolean = true;
 	public displayAppliedProxyOnBadge: boolean = true;
 	public proxyPerOrigin: boolean = true;
+	public alwaysProxyIncognito: boolean = false;
 	public enableShortcuts: boolean = true;
 	public shortcutNotification: boolean = true;
 
@@ -291,6 +295,8 @@ export class GeneralOptions implements Cloneable {
 			this.displayAppliedProxyOnBadge = source["displayAppliedProxyOnBadge"] == true ? true : false;
 		if (source["proxyPerOrigin"] != null)
 			this.proxyPerOrigin = source["proxyPerOrigin"] == true ? true : false;
+		if (source["alwaysProxyIncognito"] != null)
+			this.alwaysProxyIncognito = source["alwaysProxyIncognito"] == true ? true : false;
 		if (source["enableShortcuts"] != null)
 			this.enableShortcuts = source["enableShortcuts"] == true ? true : false;
 		if (source["shortcutNotification"] != null)

--- a/src/ui/code/settingsPage.ts
+++ b/src/ui/code/settingsPage.ts
@@ -878,6 +878,7 @@ export class settingsPage {
 		let divGeneral = jQuery("#tab-general");
 
 		divGeneral.find("#chkProxyPerOrigin").prop("checked", options.proxyPerOrigin || false);
+		divGeneral.find("#chkAlwaysProxyIncognito").prop("checked", options.alwaysProxyIncognito || false);
 
 		divGeneral.find("#chkSyncSettings").prop("checked", options.syncSettings || false);
 		divGeneral.find("#chkSyncProxyMode").prop("checked", options.syncProxyMode || false);
@@ -896,6 +897,8 @@ export class settingsPage {
 		if (environment.chrome) {
 			divGeneral.find("#chkProxyPerOrigin").attr("disabled", "disabled")
 				.parents("label").attr("disabled", "disabled");
+			divGeneral.find("#chkAlwaysProxyIncognito").attr("disabled", "disabled")
+				.parents("label").attr("disabled", "disabled");
 		}
 	}
 
@@ -905,6 +908,7 @@ export class settingsPage {
 		let divGeneral = jQuery("#tab-general");
 
 		generalOptions.proxyPerOrigin = divGeneral.find("#chkProxyPerOrigin").prop("checked");
+		generalOptions.alwaysProxyIncognito = divGeneral.find("#chkAlwaysProxyIncognito").prop("checked");
 
 		generalOptions.syncSettings = divGeneral.find("#chkSyncSettings").prop("checked");
 		generalOptions.syncProxyMode = divGeneral.find("#chkSyncProxyMode").prop("checked");

--- a/src/ui/settings.html
+++ b/src/ui/settings.html
@@ -201,6 +201,16 @@
 									</div>
 								</div>
 							</div>
+							<br>
+							<div>
+							<label class="ml-2 mr-2">
+								<input id="chkAlwaysProxyIncognito" checked type="checkbox" class="browser-style" />
+								<span data-localize="settingsGeneralAlwaysProxyIncognito">Enable always in Private Browsing mode</span>
+								<div class="form-text text-muted" data-localize="settingsGeneralAlwaysProxyIncognitoDesc">
+									Check if you want to switch to 'Always Enabled' in Private Browsing mode. This option has no effect in 'Direct' proxy mode.
+								</div>
+							</label>
+						</div>
 						</div>
 						<div>
 							<hr class="afshin-line" />


### PR DESCRIPTION
I was looking for a way to always use a SOCKS5 proxy when running in Private Browsing mode. This PR adds a respective option to the general settings page.

- When checked, Firefox always uses the configured proxy for requests originating from an incognito tab.
- When using the "Direct (No Proxy)" mode, the option is ignored altogether. I use the option in conjunction with the "System Proxy" mode and it works fine.
- I didn't bother adding support for Chrome. I didn't dig into it put it seems like some extra effort is required to support it.

Looking forward to reading your feedback 🙂 