### PR TITLE
feat: refresh active tab when profile or proxy change

### DIFF
--- a/src/_locales/default-messages.json
+++ b/src/_locales/default-messages.json
@@ -455,6 +455,10 @@
 		"message": "Display applied rule pattern on badge",
 		"description": ""
 	},
+	"settingsGeneralRefreshTabWhenProfileChange": {
+		"message": "Refresh active tab when proxy profile changed",
+		"description": ""
+	},
 	"settingsGeneralCancelButton": {
 		"message": "Cancel",
 		"description": ""

--- a/src/_locales/default-messages.json
+++ b/src/_locales/default-messages.json
@@ -455,8 +455,8 @@
 		"message": "Display applied rule pattern on badge",
 		"description": ""
 	},
-	"settingsGeneralRefreshTabWhenProfileChange": {
-		"message": "Refresh active tab when proxy profile changed",
+	"settingsGeneralRefreshTabWhenProxyChange": {
+		"message": "Refresh active tab when profile or proxy changed",
 		"description": ""
 	},
 	"settingsGeneralCancelButton": {

--- a/src/core/Core.ts
+++ b/src/core/Core.ts
@@ -691,7 +691,7 @@ export class Core {
 		dataForPopup.failedRequests = null;
 		dataForPopup.notSupportedSetProxySettings = environment.notSupported.setProxySettings;
 		dataForPopup.notAllowedSetProxySettings = environment.notAllowed.setProxySettings;
-		dataForPopup.refreshTabWhenModeChange = settings.options.refreshTabWhenModeChange;
+		dataForPopup.refreshTabWhenProxyChange = settings.options.refreshTabWhenProxyChange;
 		let themeData = new PartialThemeDataType();
 		themeData.themeType = settings.options.themeType;
 		themeData.themesLight = settings.options.themesLight;

--- a/src/core/Core.ts
+++ b/src/core/Core.ts
@@ -691,6 +691,7 @@ export class Core {
 		dataForPopup.failedRequests = null;
 		dataForPopup.notSupportedSetProxySettings = environment.notSupported.setProxySettings;
 		dataForPopup.notAllowedSetProxySettings = environment.notAllowed.setProxySettings;
+		dataForPopup.refreshTabWhenModeChange = settings.options.refreshTabWhenModeChange;
 		let themeData = new PartialThemeDataType();
 		themeData.themeType = settings.options.themeType;
 		themeData.themesLight = settings.options.themesLight;

--- a/src/core/Settings.ts
+++ b/src/core/Settings.ts
@@ -475,4 +475,3 @@ export class Settings {
 			active.currentIgnoreFailureProfile = ProfileOperations.compileSmartProfile(profileIgnoreFailureRules);
 	}
 }
-

--- a/src/core/SettingsOperation.ts
+++ b/src/core/SettingsOperation.ts
@@ -307,7 +307,7 @@ export class SettingsOperation {
 						Settings.currentOptionsSyncSettings = Settings.current.options.syncSettings;
 					},
 					(error: Error) => {
-						Debug.error(`SettingsOperation.saveAllSync error: ${error.message} ` + saveObject);
+						Debug.error(`SettingsOperation.saveAllSync error: ${error.message} `, saveObject);
 					});
 
 			} catch (e) {

--- a/src/core/definitions.ts
+++ b/src/core/definitions.ts
@@ -179,6 +179,7 @@ export class PopupInternalDataType {
 	public notSupportedSetProxySettings: boolean;
 	public notAllowedSetProxySettings: boolean;
 	public themeData: PartialThemeDataType;
+	public refreshTabWhenModeChange: boolean;
 }
 export class PartialThemeDataType {
 	public themeType: ThemeType = ThemeType.Auto;
@@ -522,6 +523,7 @@ export class GeneralOptions implements Cloneable {
 	public displayFailedOnBadge: boolean = true;
 	public displayAppliedProxyOnBadge: boolean = environment.initialConfig.displayTooltipOnBadge;
 	public displayMatchedRuleOnBadge: boolean = environment.initialConfig.displayTooltipOnBadge;
+	public refreshTabWhenModeChange: boolean = false;
 	public proxyPerOrigin: boolean = true;
 	public activeIncognitoProfileId: string;
 	public enableShortcuts: boolean = true;
@@ -545,6 +547,8 @@ export class GeneralOptions implements Cloneable {
 			this.displayAppliedProxyOnBadge = source['displayAppliedProxyOnBadge'] == true ? true : false;
 		if (source['displayMatchedRuleOnBadge'] != null)
 			this.displayMatchedRuleOnBadge = source['displayMatchedRuleOnBadge'] == true ? true : false;
+		if (source['refreshTabWhenModeChange'] != null)
+			this.refreshTabWhenModeChange = source['refreshTabWhenModeChange'] == true ? true : false;
 		if (source['proxyPerOrigin'] != null) this.proxyPerOrigin = source['proxyPerOrigin'] == true ? true : false;
 		if (source['enableShortcuts'] != null) this.enableShortcuts = source['enableShortcuts'] == true ? true : false;
 		if (source['shortcutNotification'] != null)

--- a/src/core/definitions.ts
+++ b/src/core/definitions.ts
@@ -179,7 +179,7 @@ export class PopupInternalDataType {
 	public notSupportedSetProxySettings: boolean;
 	public notAllowedSetProxySettings: boolean;
 	public themeData: PartialThemeDataType;
-	public refreshTabWhenModeChange: boolean;
+	public refreshTabWhenProxyChange: boolean;
 }
 export class PartialThemeDataType {
 	public themeType: ThemeType = ThemeType.Auto;
@@ -523,7 +523,7 @@ export class GeneralOptions implements Cloneable {
 	public displayFailedOnBadge: boolean = true;
 	public displayAppliedProxyOnBadge: boolean = environment.initialConfig.displayTooltipOnBadge;
 	public displayMatchedRuleOnBadge: boolean = environment.initialConfig.displayTooltipOnBadge;
-	public refreshTabWhenModeChange: boolean = false;
+	public refreshTabWhenProxyChange: boolean = false;
 	public proxyPerOrigin: boolean = true;
 	public activeIncognitoProfileId: string;
 	public enableShortcuts: boolean = true;
@@ -547,8 +547,8 @@ export class GeneralOptions implements Cloneable {
 			this.displayAppliedProxyOnBadge = source['displayAppliedProxyOnBadge'] == true ? true : false;
 		if (source['displayMatchedRuleOnBadge'] != null)
 			this.displayMatchedRuleOnBadge = source['displayMatchedRuleOnBadge'] == true ? true : false;
-		if (source['refreshTabWhenModeChange'] != null)
-			this.refreshTabWhenModeChange = source['refreshTabWhenModeChange'] == true ? true : false;
+		if (source['refreshTabWhenProxyChange'] != null)
+			this.refreshTabWhenProxyChange = source['refreshTabWhenProxyChange'] == true ? true : false;
 		if (source['proxyPerOrigin'] != null) this.proxyPerOrigin = source['proxyPerOrigin'] == true ? true : false;
 		if (source['enableShortcuts'] != null) this.enableShortcuts = source['enableShortcuts'] == true ? true : false;
 		if (source['shortcutNotification'] != null)

--- a/src/lib/PolyFill.ts
+++ b/src/lib/PolyFill.ts
@@ -56,6 +56,8 @@ export class PolyFill {
 	}
 	public static tabsGetCurrent(success?: Function, fail?: Function) {
 		if (environment.chrome) {
+			// Gets the tab that this script call is being made from.
+			// May be undefined if called from a non-tab context (for example, a background page or popup view).
 			api.tabs.getCurrent(
 				(tabInfo: any) => {
 					const error = PolyFill.lastError();
@@ -90,7 +92,6 @@ export class PolyFill {
 				.then(success, fail);
 		}
 	}
-
 	public static tabsReload(tabId: number, success?: Function, fail?: Function, reloadProperties?: any) {
 		if (environment.chrome) {
 			api.tabs.reload(tabId, reloadProperties,
@@ -108,8 +109,10 @@ export class PolyFill {
 		}
 	}
 	public static tabsReloadCurrent(success?: Function, fail?: Function, reloadProperties?: any) {
-		return PolyFill.tabsGetCurrent((details) => {
-			return PolyFill.tabsReload(details.id, success, fail);
+		return PolyFill.tabsQuery({ active: true, lastFocusedWindow: true }, (details) => {
+			if (details) {
+				return PolyFill.tabsReload(details.id, success, fail, reloadProperties);
+			}
 		}, fail);
 	}
 	public static tabsQuery(queryInfo: any, success?: Function, fail?: Function) {

--- a/src/lib/PolyFill.ts
+++ b/src/lib/PolyFill.ts
@@ -107,6 +107,11 @@ export class PolyFill {
 				.then(success, fail);
 		}
 	}
+	public static tabsReloadCurrent(success?: Function, fail?: Function, reloadProperties?: any) {
+		return PolyFill.tabsGetCurrent((details) => {
+			return PolyFill.tabsReload(details.id, success, fail);
+		}, fail);
+	}
 	public static tabsQuery(queryInfo: any, success?: Function, fail?: Function) {
 		if (environment.chrome) {
 			api.tabs.query(queryInfo,

--- a/src/ui/code/popup.ts
+++ b/src/ui/code/popup.ts
@@ -471,6 +471,9 @@ export class popup {
 			PolyFill.runtimeOpenOptionsPage();
 		}
 		popup.closeSelf();
+		if (popup.popupData.refreshTabWhenModeChange) {
+			PolyFill.tabsReloadCurrent();
+		}
 	}
 
 	private static onActiveProxyChange() {

--- a/src/ui/code/popup.ts
+++ b/src/ui/code/popup.ts
@@ -471,7 +471,7 @@ export class popup {
 			PolyFill.runtimeOpenOptionsPage();
 		}
 		popup.closeSelf();
-		if (popup.popupData.refreshTabWhenModeChange) {
+		if (popup.popupData.refreshTabWhenProxyChange) {
 			PolyFill.tabsReloadCurrent();
 		}
 	}

--- a/src/ui/code/popup.ts
+++ b/src/ui/code/popup.ts
@@ -471,6 +471,10 @@ export class popup {
 			PolyFill.runtimeOpenOptionsPage();
 		}
 		popup.closeSelf();
+		popup.refreshActiveTabIfNeeded();
+	}
+
+	private static refreshActiveTabIfNeeded() {
 		if (popup.popupData.refreshTabWhenProxyChange) {
 			PolyFill.tabsReloadCurrent();
 		}
@@ -487,6 +491,7 @@ export class popup {
 				command: CommandMessages.PopupChangeActiveProxyServer,
 				id
 			});
+		popup.refreshActiveTabIfNeeded();
 	}
 
 	private static onProxyableDomainClick() {

--- a/src/ui/code/settingsPage.ts
+++ b/src/ui/code/settingsPage.ts
@@ -743,7 +743,7 @@ export class settingsPage {
 		divGeneral.find("#chkShortcutNotification").prop("checked", options.shortcutNotification || false);
 		divGeneral.find("#chkDisplayAppliedProxyOnBadge").prop("checked", options.displayAppliedProxyOnBadge || false);
 		divGeneral.find("#chkDisplayMatchedRuleOnBadge").prop("checked", options.displayMatchedRuleOnBadge || false);
-		divGeneral.find("#chkRefreshTabWhenModeChange").prop("checked", options.refreshTabWhenModeChange || false);
+		divGeneral.find("#chkRefreshTabWhenProxyChange").prop("checked", options.refreshTabWhenProxyChange || false);
 
 		divGeneral.find("#rbtnThemesAutoSwitchBySystem").prop("checked", options.themeType == ThemeType.Auto);
 		divGeneral.find("#rbtnThemesLight").prop("checked", options.themeType == ThemeType.Light);
@@ -785,7 +785,7 @@ export class settingsPage {
 		generalOptions.shortcutNotification = divGeneral.find("#chkShortcutNotification").prop("checked");
 		generalOptions.displayAppliedProxyOnBadge = divGeneral.find("#chkDisplayAppliedProxyOnBadge").prop("checked");
 		generalOptions.displayMatchedRuleOnBadge = divGeneral.find("#chkDisplayMatchedRuleOnBadge").prop("checked");
-		generalOptions.refreshTabWhenModeChange = divGeneral.find("#chkRefreshTabWhenModeChange").prop("checked");
+		generalOptions.refreshTabWhenProxyChange = divGeneral.find("#chkRefreshTabWhenProxyChange").prop("checked");
 		if (divGeneral.find("#rbtnThemesLight").prop("checked")) {
 			generalOptions.themeType = ThemeType.Light;
 		}

--- a/src/ui/code/settingsPage.ts
+++ b/src/ui/code/settingsPage.ts
@@ -743,6 +743,7 @@ export class settingsPage {
 		divGeneral.find("#chkShortcutNotification").prop("checked", options.shortcutNotification || false);
 		divGeneral.find("#chkDisplayAppliedProxyOnBadge").prop("checked", options.displayAppliedProxyOnBadge || false);
 		divGeneral.find("#chkDisplayMatchedRuleOnBadge").prop("checked", options.displayMatchedRuleOnBadge || false);
+		divGeneral.find("#chkRefreshTabWhenModeChange").prop("checked", options.refreshTabWhenModeChange || false);
 
 		divGeneral.find("#rbtnThemesAutoSwitchBySystem").prop("checked", options.themeType == ThemeType.Auto);
 		divGeneral.find("#rbtnThemesLight").prop("checked", options.themeType == ThemeType.Light);
@@ -784,6 +785,7 @@ export class settingsPage {
 		generalOptions.shortcutNotification = divGeneral.find("#chkShortcutNotification").prop("checked");
 		generalOptions.displayAppliedProxyOnBadge = divGeneral.find("#chkDisplayAppliedProxyOnBadge").prop("checked");
 		generalOptions.displayMatchedRuleOnBadge = divGeneral.find("#chkDisplayMatchedRuleOnBadge").prop("checked");
+		generalOptions.refreshTabWhenModeChange = divGeneral.find("#chkRefreshTabWhenModeChange").prop("checked");
 		if (divGeneral.find("#rbtnThemesLight").prop("checked")) {
 			generalOptions.themeType = ThemeType.Light;
 		}

--- a/src/ui/settings.html
+++ b/src/ui/settings.html
@@ -48,7 +48,7 @@
 					<a class="nav-link active list-group-item list-group-item-action" id="tab-about-tab"
 						data-bs-toggle="pill" href="#tab-about" role="tab" aria-controls="tab-about"
 						aria-expanded="true">
-						<i class="fas fa-cog fa-lg text-primary" aria-hidden="true"></i>
+						<i class="fa fa-info-circle fa-lg text-primary" aria-hidden="true"></i>
 						<span data-localize="settingsTabAbout">About</span>
 					</a>
 					<a class="nav-link list-group-item list-group-item-action" id="tab-general-tab"

--- a/src/ui/settings.html
+++ b/src/ui/settings.html
@@ -421,6 +421,11 @@
 								<span data-localize="settingsGeneralDisplayAppliedRulePatternOnBadge">Display applied
 									rule pattern on badge</span>
 							</label>
+							<label class="mx-2 form-label firefox-only">
+								<input id="chkRefreshTabWhenModeChange" checked type="checkbox"
+									class="form-check-input" />
+								<span data-localize="settingsGeneralRefreshTabWhenProfileChange">Refresh current tab when proxy profile changed</span>
+							</label>
 						</div>
 						<div class="mt-5"></div>
 						<p class="mt-4"></p>

--- a/src/ui/settings.html
+++ b/src/ui/settings.html
@@ -422,9 +422,9 @@
 									rule pattern on badge</span>
 							</label>
 							<label class="mx-2 form-label">
-								<input id="chkRefreshTabWhenModeChange" checked type="checkbox"
+								<input id="chkRefreshTabWhenProxyChange" checked type="checkbox"
 									class="form-check-input" />
-								<span data-localize="settingsGeneralRefreshTabWhenProfileChange">Refresh active tab when proxy profile changed</span>
+								<span data-localize="settingsGeneralRefreshTabWhenProxyChange">Refresh active tab when proxy profile changed</span>
 							</label>
 						</div>
 						<div class="mt-5"></div>

--- a/src/ui/settings.html
+++ b/src/ui/settings.html
@@ -421,10 +421,10 @@
 								<span data-localize="settingsGeneralDisplayAppliedRulePatternOnBadge">Display applied
 									rule pattern on badge</span>
 							</label>
-							<label class="mx-2 form-label firefox-only">
+							<label class="mx-2 form-label">
 								<input id="chkRefreshTabWhenModeChange" checked type="checkbox"
 									class="form-check-input" />
-								<span data-localize="settingsGeneralRefreshTabWhenProfileChange">Refresh current tab when proxy profile changed</span>
+								<span data-localize="settingsGeneralRefreshTabWhenProfileChange">Refresh active tab when proxy profile changed</span>
 							</label>
 						</div>
 						<div class="mt-5"></div>


### PR DESCRIPTION
this close: #170 

![CleanShot 2022-09-18 at 12 21 44@2x](https://user-images.githubusercontent.com/13938334/190885609-2d6389cc-b507-46bf-9540-7f65951d7ef3.png)

add an option to enable this feature.

you can see this video:


https://user-images.githubusercontent.com/13938334/190885669-94d0a85e-3784-4d66-9369-9d57a6e1c6cb.mp4


and the translated message seems should translated in the website, maybe need opeated after merge this pr.
