### PR TITLE
Reload tab when 1) Clicking on Proxyable Domain and 2) Adding Failed Requests to Rule Lists

### DIFF
--- a/src/ui/code/popup.ts
+++ b/src/ui/code/popup.ts
@@ -521,6 +521,7 @@ export class popup {
 				ruleId: proxyableDomain.ruleId
 			});
 
+			popup.refreshActiveTabIfNeeded();
 			popup.closeSelf();
 		} else {
 			PolyFill.runtimeSendMessage(`rule is not for this domain: ${domain}`);
@@ -574,9 +575,12 @@ export class popup {
 							}
 							let result = response.result;
 							if (result) {
-								if (result.success && result.message) {
-									messageBox.success(result.message, 4000);
-									close = false;
+								if (result.success) {
+									popup.refreshActiveTabIfNeeded();
+									if (result.message) {
+										messageBox.success(result.message, 4000);
+										close = false;
+									}
 								}
 								else if (!result.success && result.message) {
 									messageBox.error(result.message);


### PR DESCRIPTION
For #301.

If "Setting" -> "Refresh active tab when profile or proxy changed" is on , do reload when 1) Clicking on Proxyable Domain and 2) Adding Failed Requests to Rule Lists