### PR TITLE
ignore link check when user has not selected a custom theme

### DIFF
--- a/src/ui/code/settingsPage.ts
+++ b/src/ui/code/settingsPage.ts
@@ -2051,15 +2051,18 @@ export class settingsPage {
 		},
 		onClickSaveGeneralOptions() {
 			let generalOptions = settingsPage.readGeneralOptions();
-
-			if (generalOptions.themeType === ThemeType.Light && generalOptions.themesLight == themesCustomType){
-				if (!Utils.isValidUrl(generalOptions.themesLightCustomUrl)) {
+			if (generalOptions.themeType === ThemeType.Light && generalOptions.themesLight === themesCustomType){
+				if (!Utils.isValidUrl(generalOptions.themesLightCustomUrl) || !Utils.isUrlHttps(generalOptions.themesLightCustomUrl)) {
 					// Please enter a valid Light Theme and the url should be 'https'.
 					messageBox.error(api.i18n.getMessage("settingsGeneralThemesLight_ErrorValidUrl"));
 					return;
 				}
-				if (!Utils.isUrlHttps(generalOptions.themesLightCustomUrl)) {
-					messageBox.error(api.i18n.getMessage("settingsGeneralThemesLight_ErrorValidUrl"));
+			}
+
+			if (generalOptions.themeType === ThemeType.Dark && generalOptions.themesDark === themesCustomType) {
+				if (!Utils.isValidUrl(generalOptions.themesDarkCustomUrl) || !Utils.isUrlHttps(generalOptions.themesDarkCustomUrl)) {
+					// Please enter a valid Dark Theme and the url should be 'https'.
+					messageBox.error(api.i18n.getMessage("settingsGeneralThemesDark_ErrorValidUrl"));
 					return;
 				}
 			}

--- a/src/ui/code/settingsPage.ts
+++ b/src/ui/code/settingsPage.ts
@@ -2052,7 +2052,7 @@ export class settingsPage {
 		onClickSaveGeneralOptions() {
 			let generalOptions = settingsPage.readGeneralOptions();
 
-			if (generalOptions.themesLight == themesCustomType) {
+			if (generalOptions.themeType === ThemeType.Light && generalOptions.themesLight == themesCustomType){
 				if (!Utils.isValidUrl(generalOptions.themesLightCustomUrl)) {
 					// Please enter a valid Light Theme and the url should be 'https'.
 					messageBox.error(api.i18n.getMessage("settingsGeneralThemesLight_ErrorValidUrl"));
@@ -2060,17 +2060,6 @@ export class settingsPage {
 				}
 				if (!Utils.isUrlHttps(generalOptions.themesLightCustomUrl)) {
 					messageBox.error(api.i18n.getMessage("settingsGeneralThemesLight_ErrorValidUrl"));
-					return;
-				}
-			}
-			if (generalOptions.themesDark == themesCustomType) {
-				if (!Utils.isValidUrl(generalOptions.themesDarkCustomUrl)) {
-					// Please enter a valid Dark Theme and the url should be 'https'.
-					messageBox.error(api.i18n.getMessage("settingsGeneralThemesDark_ErrorValidUrl"));
-					return;
-				}
-				if (!Utils.isUrlHttps(generalOptions.themesDarkCustomUrl)) {
-					messageBox.error(api.i18n.getMessage("settingsGeneralThemesDark_ErrorValidUrl"));
 					return;
 				}
 			}


### PR DESCRIPTION
Clicking Save will trigger an error when the user forgets to fill in the custom link and switches to another theme.

![ignore theme link check](https://github.com/salarcode/SmartProxy/assets/5570324/9a3d17c6-66cf-40d4-9867-3b477924ab60)
