### PR TITLE
fix: subscription refresh not happening sometimes

### DIFF
--- a/src/core/SubscriptionUpdater.ts
+++ b/src/core/SubscriptionUpdater.ts
@@ -84,13 +84,9 @@ export class SubscriptionUpdater {
 			if (shouldCreate) {
 				let nextFetchInMs: number;
 				if (subscription.stats?.lastTryDate) {
-					const timeSinceLastTry =
-						Date.now() -
-						(new Date(subscription.stats.lastTryDate)).getTime();
-					nextFetchInMs = Math.max(
-						subscription.refreshRate * 60 * 1000 - timeSinceLastTry,
-						0
-					);
+					const timeSinceLastTry = Date.now() - (new Date(subscription.stats.lastTryDate)).getTime();
+					
+					nextFetchInMs = Math.max(0, subscription.refreshRate * 60 * 1000 - timeSinceLastTry);
 				} else {
 					nextFetchInMs = 0;
 				}
@@ -252,22 +248,18 @@ export class SubscriptionUpdater {
 				if (shouldCreate) {
 					let nextFetchInMs: number;
 					if (subscription.stats?.lastTryDate) {
-						const timeSinceLastTry =
-							Date.now() -
-							(new Date(subscription.stats.lastTryDate)).getTime();
-						nextFetchInMs = Math.max(
-							subscription.refreshRate * 60 * 1000 - timeSinceLastTry,
-							0
-						);
+						const timeSinceLastTry = Date.now() - (new Date(subscription.stats.lastTryDate)).getTime();
+						
+						nextFetchInMs = Math.max(0, subscription.refreshRate * 60 * 1000 - timeSinceLastTry);
 					} else {
 						nextFetchInMs = 0;
 					}
-	
+
 					// This is like `setInterval`, but with an offset first invocation.
 					// Yes, `clearInterval` also works on `setTimeout` IDs.
 					const setTimeoutId = setTimeout(() => {
 						SubscriptionUpdater.readRulesSubscription(subscription);
-	
+
 						// Start using `setInterval` from now on.
 						const intervalId = setInterval(
 							SubscriptionUpdater.readRulesSubscription,
@@ -276,7 +268,7 @@ export class SubscriptionUpdater {
 						);
 						timerObj.timerId = intervalId;
 					}, nextFetchInMs);
-	
+
 					const timerObj = {
 						timerId: setTimeoutId,
 						subscriptionId: subscription.id,

--- a/src/core/definitions.ts
+++ b/src/core/definitions.ts
@@ -2,6 +2,7 @@
 import { api, environment } from '../lib/environment';
 import { Utils } from '../lib/Utils';
 import { ProfileOperations } from './ProfileOperations';
+import { Debug } from '../lib/Debug';
 
 /*
  * This file is part of SmartProxy <https://github.com/salarcode/SmartProxy>,
@@ -961,16 +962,15 @@ export class SubscriptionStats {
 
 	public static updateStats(stats: SubscriptionStats, success: boolean, errorResult?: any) {
 		let now = new Date();
+		stats.lastTryDate = now.toISOString();
 		if (success) {
 			stats.lastStatus = true;
 			stats.lastStatusMessage = null;
-			stats.lastTryDate =
-				stats.lastSuccessDate = now.toLocaleDateString() + ' ' + now.toLocaleTimeString();
+			stats.lastSuccessDate = now.toLocaleDateString() + ' ' + now.toLocaleTimeString();
 		}
 		else {
 			stats.lastStatus = false;
 			stats.lastStatusMessage = errorResult?.message ?? errorResult?.toString();
-			stats.lastTryDate = now.toLocaleDateString() + ' ' + now.toLocaleTimeString();
 		}
 		stats.lastStatusProxyServerName = Settings.active?.currentProxyServer?.name;
 	}
@@ -985,7 +985,13 @@ export class SubscriptionStats {
 
 		if (!stats.lastStatus) {
 			if (stats.lastTryDate) {
-				status += `\r\n${api.i18n.getMessage("settingsSubscriptionStatsLastTry")} ${stats.lastTryDate}`
+				try {
+					let lastTryDate = new Date(stats.lastTryDate);
+					let lastTryDateText = lastTryDate.toLocaleDateString() + ' ' + lastTryDate.toLocaleTimeString();
+					status += `\r\n${api.i18n.getMessage("settingsSubscriptionStatsLastTry")} ${lastTryDateText}`
+				} catch (error) {
+					Debug.warn(`SubscriptionStats.lastTryDate has invalid (probably old) value`, error);
+				}
 			}
 			else {
 				status += `\r\n${api.i18n.getMessage("settingsSubscriptionStatsLastTry")} -`


### PR DESCRIPTION
Since the background scripts in MV3 are non-persistent, they might shut down often, losing all `setInterval` timers.

If the background script doesn't live longer that refresh period, then it will never refresh.

This commit checks `lastTryDate` and does `setTimeout` based on that. If the list has not been refreshed for longer than `refreshRate`, we'll refresh it immediately.

FYI however there is another bug: if a fetch fails, `lastTryDate` does not get stored in local storage, so a refresh attempt will happen immediately
as the background script starts.
This is not a big problem.