### PR TITLE
Fix proxy per tab/origin feature

### DIFF
--- a/src/core/ProxyEngineFirefox.ts
+++ b/src/core/ProxyEngineFirefox.ts
@@ -186,6 +186,8 @@ export class ProxyEngineFirefox {
 				// in incognito tab/window switching to use the specified profile
 				activeProfile = activeIncognitoProfile;
 				activeProfileType = activeIncognitoProfile.profileType;
+			} else if (requestDetails.tabId > -1) {
+				tabData = TabManager.getTab(requestDetails.tabId);
 			}
 
 			if (activeProfileType === SmartProfileType.Direct ||


### PR DESCRIPTION
In b486a8c252, in an attempt to fix incognito profile not applying, a fix was made to check for incognito on request details, rather than the tab data. This fix, however, had an unfortunate side effect of removing assignment of `tabData`. That resulted in profile not applying to any of the requests made on the tab, completely breaking the proxy per tab/origin feature.

This PR brings back assignment of `tabData`, but only if previous incognito condition did not apply, which should hopefully correct the previous incognito fix, making proxy per tab/origin feature functional again.

Fixes #403
