### PR TITLE
Support IP/CIDR rules conversion from SwitchyOmega

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
       "name": "SmartProxy",
       "license": "GPL-3.0",
       "dependencies": {
+        "ip-address": "5.8.9",
         "pako": "^2.1.0",
         "webdav": "^5.9.0"
       },
@@ -4610,6 +4611,30 @@
         "node": ">=10.13.0"
       }
     },
+    "node_modules/ip-address": {
+      "version": "5.8.9",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-5.8.9.tgz",
+      "integrity": "sha512-7ay355oMN34iXhET1BmCJVsHjOTSItEEIIpOs38qUC23AIhOy+xIPnkrTuEFjeLMrTJ7m8KMXWgWfy/2Vn9sDw==",
+      "license": "MIT",
+      "dependencies": {
+        "jsbn": "1.1.0",
+        "lodash.find": "^4.6.0",
+        "lodash.max": "^4.0.1",
+        "lodash.merge": "^4.6.0",
+        "lodash.padstart": "^4.6.1",
+        "lodash.repeat": "^4.1.0",
+        "sprintf-js": "1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/ip-address/node_modules/sprintf-js": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.0.tgz",
+      "integrity": "sha512-F5Eiffg9i6Jcq0H3iSr/2HQXTw3/BlrWqxDXS45szJfgR8EBTfQogrPXMxmJ6ylyvwE2XC4MTxPKO5/ivODOnQ==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
@@ -5725,6 +5750,12 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
+    "node_modules/jsbn": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-1.1.0.tgz",
+      "integrity": "sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A==",
+      "license": "MIT"
+    },
     "node_modules/jsdom": {
       "version": "26.1.0",
       "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-26.1.0.tgz",
@@ -5906,11 +5937,41 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/lodash.find": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.find/-/lodash.find-4.6.0.tgz",
+      "integrity": "sha512-yaRZoAV3Xq28F1iafWN1+a0rflOej93l1DQUejs3SZ41h2O9UJBoS9aueGjPDgAl4B6tPC0NuuchLKaDQQ3Isg==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.max": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.max/-/lodash.max-4.0.1.tgz",
+      "integrity": "sha512-iykTDTb7PK33HSQmKy34zv+hh4WEu7WonJPXQcgODzUbbtradtNs8RsD/GI7XV++60KaKR1xhW56N4ISqHesfQ==",
+      "license": "MIT"
+    },
     "node_modules/lodash.memoize": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
       "integrity": "sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.padstart": {
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/lodash.padstart/-/lodash.padstart-4.6.1.tgz",
+      "integrity": "sha512-sW73O6S8+Tg66eY56DBk85aQzzUJDtpoXFBgELMd5P/SotAguo+1kYO6RuYgXxA4HJH3LFTFPASX6ET6bjfriw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.repeat": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/lodash.repeat/-/lodash.repeat-4.1.0.tgz",
+      "integrity": "sha512-eWsgQW89IewS95ZOcr15HHCX6FVDxq3f2PNUIng3fyzsPev9imFQxIYdFZ6crl8L56UR6ZlGDLcEb3RZsCSSqw==",
       "license": "MIT"
     },
     "node_modules/lru-cache": {

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
   },
   "license": "GPL-3.0",
   "dependencies": {
+    "ip-address": "5.8.9",
     "pako": "^2.1.0",
     "webdav": "^5.9.0"
   }

--- a/src/core/ProxyEngineChrome.ts
+++ b/src/core/ProxyEngineChrome.ts
@@ -141,7 +141,7 @@ function FindProxyForURL(url, host, noDiagnostics) {
 		// subscription skip bypass rules/ don't apply proxy
 		let subMatchedRule = findMatchedUrlInRules(url, host, hostAndPort, compiledRules.SubscriptionRules);
 		if (subMatchedRule) {
-			return makeResultForAlwaysEnabledForced(userMatchedRule)
+			return makeResultForAlwaysEnabledForced(subMatchedRule)
 		}
 
 		// subscription bypass rules/ apply proxy by force

--- a/src/lib/RuleImporterSwitchy.js
+++ b/src/lib/RuleImporterSwitchy.js
@@ -442,9 +442,9 @@ const Conditions = {
 	},
 	normalizeIp: function (addr) {
 		let ref1;
-		return ((ref1 = addr.correctForm) != null ? ref1 : addr.canonicalForm).call(addr);
+		return ((ref1 = addr.canonicalForm) != null ? ref1 : addr.correctForm).call(addr);
 	},
-	//ipv6Max: new IP.v6.Address('::/0').endAddress().canonicalForm(),
+	ipv6Max: new IP.v6.Address('::/0').endAddress().canonicalForm(),
 	localHosts: ["127.0.0.1", "[::1]", "localhost"],
 	getWeekdayList: function (condition) {
 		let i, j, k, results, results1;

--- a/src/lib/RuleImporterSwitchy.js
+++ b/src/lib/RuleImporterSwitchy.js
@@ -6,6 +6,13 @@
 * @source  https://github.com/FelisCatus/SwitchyOmega
 * @license  GPL3
 */
+const Utils = require('./Utils').Utils;
+const { Address4, Address6 } = require('ip-address');
+const IP = {
+  v4: { Address: Address4 },
+  v6: { Address: Address6 }
+};
+
 const strStartsWith = function (str, prefix) {
 	return str.substr(0, prefix.length) === prefix;
 };
@@ -871,101 +878,12 @@ const Conditions = {
 				return addr.isInSubnet(cache.addr);
 			},
 			compile: function (condition, cache) {
-				let hostIsInNet, hostIsInNetEx, hostLooksLikeIp;
 				cache = cache.analyzed;
-				hostLooksLikeIp = cache.addr.v4 ? new U2.AST_Binary({
-					left: new U2.AST_Sub({
-						expression: new U2.AST_SymbolRef({
-							name: 'host'
-						}),
-						property: new U2.AST_Binary({
-							left: new U2.AST_Dot({
-								expression: new U2.AST_SymbolRef({
-									name: 'host'
-								}),
-								property: 'length'
-							}),
-							operator: '-',
-							right: new U2.AST_Number({
-								value: 1
-							})
-						})
-					}),
-					operator: '>=',
-					right: new U2.AST_Number({
-						value: 0
-					})
-				}) : new U2.AST_Binary({
-					left: new U2.AST_Call({
-						expression: new U2.AST_Dot({
-							expression: new U2.AST_SymbolRef({
-								name: 'host'
-							}),
-							property: 'indexOf'
-						}),
-						args: [
-							new U2.AST_String({
-								value: ':'
-							})
-						]
-					}),
-					operator: '>=',
-					right: new U2.AST_Number({
-						value: 0
-					})
-				});
-				if (cache.addr.subnetMask === 0) {
-					return hostLooksLikeIp;
+				let regex = Utils.ipCidrNotationToRegExp(cache.normalized, cache.addr.parsedSubnet);
+				if (!regex) {
+					throw new Error(`Failed to compile CIDR rule ${cache.normalized}/${cache.addr.parsedSubnet} to regex`);
 				}
-				hostIsInNet = new U2.AST_Call({
-					expression: new U2.AST_SymbolRef({
-						name: 'isInNet'
-					}),
-					args: [
-						new U2.AST_SymbolRef({
-							name: 'host'
-						}), new U2.AST_String({
-							value: cache.normalized
-						}), new U2.AST_String({
-							value: cache.mask
-						})
-					]
-				});
-				if (!cache.addr.v4) {
-					hostIsInNetEx = new U2.AST_Call({
-						expression: new U2.AST_SymbolRef({
-							name: 'isInNetEx'
-						}),
-						args: [
-							new U2.AST_SymbolRef({
-								name: 'host'
-							}), new U2.AST_String({
-								value: cache.normalized + cache.addr.subnet
-							})
-						]
-					});
-					hostIsInNet = new U2.AST_Conditional({
-						condition: new U2.AST_Binary({
-							left: new U2.AST_UnaryPrefix({
-								operator: 'typeof',
-								expression: new U2.AST_SymbolRef({
-									name: 'isInNetEx'
-								})
-							}),
-							operator: '===',
-							right: new U2.AST_String({
-								value: 'function'
-							})
-						}),
-						consequent: hostIsInNetEx,
-						alternative: hostIsInNet
-					});
-				}
-				return new U2.AST_Binary({
-					left: hostLooksLikeIp,
-					operator: '&&',
-					right: hostIsInNet
-				});
+				return this.regTest('host', regex);
 			},
 			str: function (condition) {
 				return condition.ip + '/' + condition.prefixLength;


### PR DESCRIPTION
Currently, IP conditions from SwitchyOmega cannot be converted into internal RegExp rules. 

This PR implements the conversion logic using Utils.ipCidrNotationToRegExp to ensure IP-based routing works correctly in PAC scripts.

Tested locally with [these rules](https://raw.githubusercontent.com/OriginVorfeed/switchyomega-china-list/refs/heads/main/white-list-base.sorl).